### PR TITLE
add IGNORE_SQL_PATTERNS option to ignore the specified sql query

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,6 @@
-Django Querycount
+forked from Django Querycount
 =================
+add SQL statistic ignore pattern support. 
 
 |version| |license|
 

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,5 @@
-forked from Django Querycount
+Django Querycount
 =================
-add SQL statistic ignore pattern support. 
 
 |version| |license|
 
@@ -35,7 +34,8 @@ that will be ignored by the middleware.  The default settings are::
             'MIN_TIME_TO_LOG':0,
             'MIN_QUERY_COUNT_TO_LOG':0
         },
-        'IGNORE_PATTERNS': [],
+        'IGNORE_REQUEST_PATTERNS': [],
+        'IGNORE_SQL_PATTERNS': []
     }
 
 
@@ -44,14 +44,23 @@ interpreted as high or medium (and the color-coded output). In previous versions
 of this app, this settings was called ``QUERYCOUNT_THRESHOLDS`` and that setting
 is still supported.
 
-The ``QUERYCOUT['IGNORE_PATTERNS']`` setting allows you to define a list of
+The ``QUERYCOUT['IGNORE_REQUEST_PATTERNS']`` setting allows you to define a list of
 regexp patterns that get applied to each request's path. If there is a match,
 the middleware will not be applied to that request. For example, the following
 setting would bypass the querycount middleware for all requests to the admin::
 
     QUERYCOUNT = {
-        'IGNORE_PATTERNS': [r'^/admin/']
+        'IGNORE_REQUEST_PATTERNS': [r'^/admin/']
     }
+
+The ``QUERYCOUT['IGNORE_SQL_PATTERNS']`` setting allows you to define a list of
+regexp patterns that ignored to statistic sql query count. For example, the following
+setting would bypass the querycount middleware for django-silk sql query::
+
+    QUERYCOUNT = {
+        'IGNORE_SQL_PATTERNS': [r'silk_']
+    }
+
 
 
 License

--- a/querycount/middleware.py
+++ b/querycount/middleware.py
@@ -13,7 +13,7 @@ class QueryCountMiddleware(object):
     """This middleware prints the number of database queries for each http
     request and response. This code is adapted from: http://goo.gl/UUKN0r"""
 
-    read_query_regex = re.compile("SELECT .*")
+    READ_QUERY_REGEX = re.compile("SELECT .*")
 
     def __init__(self, *args, **kwargs):
         if settings.DEBUG:
@@ -47,7 +47,7 @@ class QueryCountMiddleware(object):
         for c in connections.all():
             for q in c.queries:
                 if not self._ignore_sql(q):
-                    if self.read_query_regex.search(q['sql']) is not None:
+                    if self.READ_QUERY_REGEX.search(q['sql']) is not None:
                         self.stats[which][c.alias]['reads'] += 1
                     else:
                         self.stats[which][c.alias]['writes'] += 1

--- a/querycount/middleware.py
+++ b/querycount/middleware.py
@@ -13,6 +13,8 @@ class QueryCountMiddleware(object):
     """This middleware prints the number of database queries for each http
     request and response. This code is adapted from: http://goo.gl/UUKN0r"""
 
+    read_query_regex = re.compile("SELECT .*")
+
     def __init__(self, *args, **kwargs):
         if settings.DEBUG:
             self.request_path = None
@@ -32,7 +34,6 @@ class QueryCountMiddleware(object):
 
             # query type detection regex
             # TODO: make stats classification regex more robust
-            self.read_query_regex = re.compile("SELECT .*")
             self.threshold = QC_SETTINGS['THRESHOLDS']
             super(QueryCountMiddleware, self).__init__(*args, **kwargs)
 
@@ -45,27 +46,34 @@ class QueryCountMiddleware(object):
     def _count_queries(self, which):
         for c in connections.all():
             for q in c.queries:
-                if self.read_query_regex.search(q['sql']) is not None:
-                    self.stats[which][c.alias]['reads'] += 1
-                else:
-                    self.stats[which][c.alias]['writes'] += 1
-                self.stats[which][c.alias]['total'] += 1
+                if not self._ignore_sql(q):
+                    if self.read_query_regex.search(q['sql']) is not None:
+                        self.stats[which][c.alias]['reads'] += 1
+                    else:
+                        self.stats[which][c.alias]['writes'] += 1
+                    self.stats[which][c.alias]['total'] += 1
 
-    def _ignore(self, path):
+    def _ignore_request(self, path):
         """Check to see if we should ignore the request."""
         return any([
-            re.match(pattern, path) for pattern in QC_SETTINGS['IGNORE_PATTERNS']
+            re.match(pattern, path) for pattern in QC_SETTINGS['IGNORE_REQUEST_PATTERNS']
+        ])
+
+    def _ignore_sql(self, query):
+        """Check to see if we should ignore the sql query."""
+        return any([
+            re.search(pattern, query['sql']) for pattern in QC_SETTINGS['IGNORE_SQL_PATTERNS']
         ])
 
     def process_request(self, request):
-        if settings.DEBUG and not self._ignore(request.path):
+        if settings.DEBUG and not self._ignore_request(request.path):
             self.host = request.META.get('HTTP_HOST', None)
             self.request_path = request.path
             self._start_time = timeit.default_timer()
             self._count_queries("request")
 
     def process_response(self, request, response):
-        if settings.DEBUG and not self._ignore(request.path):
+        if settings.DEBUG and not self._ignore_request(request.path):
             self.request_path = request.path
             self._end_time = timeit.default_timer()
             self._count_queries("response")

--- a/querycount/qc_settings.py
+++ b/querycount/qc_settings.py
@@ -7,7 +7,8 @@ from django.conf import settings
 
 
 QC_SETTINGS = {
-    'IGNORE_PATTERNS': [],
+    'IGNORE_REQUEST_PATTERNS': [],
+    'IGNORE_SQL_PATTERNS': [],
     'THRESHOLDS': {
         'MEDIUM': 50,
         'HIGH': 200,
@@ -19,9 +20,17 @@ QC_SETTINGS = {
 if getattr(settings, 'QUERYCOUNT', False) and 'THRESHOLDS' in settings.QUERYCOUNT:
     QC_SETTINGS['THRESHOLDS'] = settings.QUERYCOUNT['THRESHOLDS']
 
-if getattr(settings, 'QUERYCOUNT', False) and 'IGNORE_PATTERNS' in settings.QUERYCOUNT:
-    QC_SETTINGS['IGNORE_PATTERNS'] = settings.QUERYCOUNT['IGNORE_PATTERNS']
+if getattr(settings, 'QUERYCOUNT', False) and 'IGNORE_REQUEST_PATTERNS' in settings.QUERYCOUNT:
+    QC_SETTINGS['IGNORE_REQUEST_PATTERNS'] = settings.QUERYCOUNT['IGNORE_REQUEST_PATTERNS']
+
+if getattr(settings, 'QUERYCOUNT', False) and 'IGNORE_SQL_PATTERNS' in settings.QUERYCOUNT:
+    QC_SETTINGS['IGNORE_SQL_PATTERNS'] = settings.QUERYCOUNT['IGNORE_SQL_PATTERNS']
+
+# Support the old-style settings
 
 # Support the old-style settings
 if getattr(settings, 'QUERYCOUNT_THRESHOLDS', False):
     QC_SETTINGS['THRESHOLDS'] = settings.QUERYCOUNT_THRESHOLDS
+
+if getattr(settings, 'QUERYCOUNT', False) and 'IGNORE_PATTERNS' in settings.QUERYCOUNT:
+    QC_SETTINGS['IGNORE_REQUEST_PATTERNS'] = settings.QUERYCOUNT['IGNORE_PATTERNS']


### PR DESCRIPTION
Now django-querycount statistic all sql querys, this pr makes django-querycount can filter sql query by IGNORE_SQL_PATTERNS.