### PR TITLE
Support Django 1.10 middleware

### DIFF
--- a/querycount/middleware.py
+++ b/querycount/middleware.py
@@ -10,8 +10,13 @@ from django.utils import termcolors
 
 from . qc_settings import QC_SETTINGS
 
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    MiddlewareMixin = object
 
-class QueryCountMiddleware(object):
+
+class QueryCountMiddleware(MiddlewareMixin):
     """This middleware prints the number of database queries for each http
     request and response. This code is adapted from: http://goo.gl/UUKN0r"""
 


### PR DESCRIPTION
This adds support for Django 1.10-style middleware: https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware