### PR TITLE
Feature/response header count and setting reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pyc
 *.swp
+.cache/*
+.vscode/*

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -6,3 +6,4 @@ Authors & Contributors
 - Alonisser `<https://github.com/alonisser>`_
 - GitFree `<https://github.com/GitFree>`_
 - Ryan Kaskel `<https://github.com/ryankask>`_
+- Josh O'Neal `<https://github.com/lifecoder45>`_

--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,7 @@ that will be ignored by the middleware.  The default settings are::
         'IGNORE_REQUEST_PATTERNS': [],
         'IGNORE_SQL_PATTERNS': [],
         'DISPLAY_DUPLICATES': None,
+        'RESPONSE_HEADER': 'X-DjangoQueryCount-Count'
     }
 
 
@@ -62,6 +63,13 @@ setting would bypass the querycount middleware for django-silk sql query::
         'IGNORE_SQL_PATTERNS': [r'silk_']
     }
 
+The ``QUERYCOUNT['RESPONSE_HEADER']`` setting allows you to define a custom response
+header that contains the total number of queries executed. To disable this header, 
+the supply ``None`` as the value:
+
+    QUERYCOUNT = {
+        'RESPONSE_HEADER': None
+    }
 
 **New in 0.4.0**. The ``QUERYCOUNT['DISPLAY_DUPLICATES']`` setting allows you
 to control how the most common duplicate queries are displayed. If the setting

--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ setting would bypass the querycount middleware for django-silk sql query::
 
 The ``QUERYCOUNT['RESPONSE_HEADER']`` setting allows you to define a custom response
 header that contains the total number of queries executed. To disable this header, 
-the supply ``None`` as the value:
+the supply ``None`` as the value::
 
     QUERYCOUNT = {
         'RESPONSE_HEADER': None

--- a/querycount/tests/test.py
+++ b/querycount/tests/test.py
@@ -12,6 +12,7 @@ DEFAULT_QC_SETTINGS = {
     'IGNORE_REQUEST_PATTERNS': [],
     'IGNORE_SQL_PATTERNS': [],
     'DISPLAY_DUPLICATES': None,
+    'RESPONSE_HEADER': 'X-DjangoQueryCount-Count'
 }
 
 QC_MIDDLEWARE = {
@@ -49,3 +50,14 @@ class QueryCountTestCase(TestCase):
         # Smoke test for a view that does a single DB queries.
         resp = self.client.get("/count/")
         self.assertEqual(resp.status_code, 200)
+        self.assertEqual(int(resp['X-DjangoQueryCount-Count']), 1)
+
+    def test_header_disabled(self):
+        # Ensure removing the count header is effective
+        disabled_settings = DEFAULT_QC_SETTINGS
+        disabled_settings['RESPONSE_HEADER'] = None
+
+        with self.settings(QUERYCOUNT=disabled_settings):
+            resp = self.client.get("/count/")            
+            self.assertEqual(resp.status_code, 200)
+            self.assertFalse('X-DjangoQueryCount-Count' in resp)


### PR DESCRIPTION
This PR adds functionality to return a custom response header with total request & response query count. We plan to use this functionality in our integration test suite, to ensure all endpoints are under the allowed count.

Additionally, when attempting to override the settings to ensure the header was being removed, I found the need to ensure the settings are reloaded, so I've cleaned up the settings application and wired them up to the Django setting changed signal.