### PR TITLE
Replace `\` with `\\` to fix regex compile error when binary data is present in the query

### DIFF
--- a/querycount/middleware.py
+++ b/querycount/middleware.py
@@ -83,7 +83,7 @@ class QueryCountMiddleware(MiddlewareMixin):
                             r'\1#number#\2', where_clause_match.group(2))
                         repl = 'r\1{}\3' if where_clause_match.group(3) else r'\1{}'
                         sql = self.WHERE_CLAUSE_REGEX.sub(
-                            repl.format(criteria_clause), sql)
+                            repl.format(criteria_clause.replace('\\', '\\\\')), sql)
 
                     self.queries[sql] += 1
 


### PR DESCRIPTION
If a query is executed with binary data in the query (such as when using PostGIS and `ST_GeomFromEWKB`), the middleware crashes with a regex compile error.

To replicate the issue, execute a query with the middleware in place, such as;

```SELECT * FROM table WHERE ST_Contains("table"."column", ST_GeomFromEWKB('\x0101000020e61000004606b98b308d3a403a3c84f1d30554c0'::bytea))```