### PR TITLE
To avoid error when lunching runserver (QUERY_STRING)

### DIFF
--- a/querycount/middleware.py
+++ b/querycount/middleware.py
@@ -106,7 +106,7 @@ class QueryCountMiddleware(MiddlewareMixin):
         if settings.DEBUG and not self._ignore_request(request.path):
             self.host = request.META.get('HTTP_HOST', None)
             self.request_path = request.path
-            self.query_string = request.META['QUERY_STRING']
+            self.query_string = request.META.get('QUERY_STRING', None)
             self._start_time = timeit.default_timer()
             self._count_queries("request")
 


### PR DESCRIPTION
To avoid getting an error when launching the runserver if QUERY_STRING has not yet been set.

```shell
2024-05-29 09:20:41,724 django.request - ERROR Internal Server Error: /
Traceback (most recent call last):
  File ".../lib/python3.12/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File ".../lib/python3.12/site-packages/django/utils/deprecation.py", line 133, in __call__
    response = self.process_request(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../lib/python3.12/site-packages/querycount/middleware.py", line 109, in process_request
    self.query_string = request.META['QUERY_STRING']
                        ~~~~~~~~~~~~^^^^^^^^^^^^^^^^
KeyError: 'QUERY_STRING'
```